### PR TITLE
[+] Sky condition parsing from metar reports

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
 
 - [Andrey Shuliak](https://github.com/Veon2479)
 - [Viktar Astreika](https://github.com/ViktarRainbow)
+- [Alexander Lemeza](http://github.com/azeme1)

--- a/tests/metrics/parse/observation/test_metar.py
+++ b/tests/metrics/parse/observation/test_metar.py
@@ -2,7 +2,7 @@ import datetime
 import pytest
 import typing
 
-from metrics.parse.observation.metar import MetarParser
+from metrics.parse.observation.metar import CLOUD_BASE_UNDEFINED, MetarParser, SkyCover
 from metrics.utils.precipitation import PrecipitationType
 from unittest.mock import MagicMock, patch
 
@@ -15,7 +15,11 @@ def _create_metar_file(raw_text: str = "TJBQ 251150Z 00000KT 10SM CLR 25/21 A299
                        temp_c: float = 25.4,
                        dew_point: float = 21,
                        wind_dir_degrees: float = 5.4,
-                       wind_speed_kt: float = 23.0) -> str:
+                       wind_speed_kt: float = 23.0,
+                       sky_condition: typing.List[str] = []) -> str:
+
+    sky_condition_str = "\n".join(sky_condition)
+
     return f'''
 <response xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.3" xsi:noNamespaceSchemaLocation="https://aviationweather.gov/data/schema/metar1_3.xsd">
   <request_index>1711367461</request_index>
@@ -37,7 +41,7 @@ def _create_metar_file(raw_text: str = "TJBQ 251150Z 00000KT 10SM CLR 25/21 A299
       <wind_speed_kt>{wind_speed_kt}</wind_speed_kt>
       <visibility_statute_mi>10+</visibility_statute_mi>
       <altim_in_hg>29.90</altim_in_hg>
-      <sky_condition sky_cover="CLR"/>
+      {sky_condition_str}
       <flight_category>VFR</flight_category>
       <metar_type>METAR</metar_type>
       <elevation_m>69</elevation_m>
@@ -61,6 +65,28 @@ class TestMetarParser:
         assert parser._parse_timestamp(time_str) == expected_timestamp
 
     @pytest.mark.parametrize("sample_xml, report_timestamp, expected_rows", [
+        # clear sky without sky condition reporting
+        (
+            _create_metar_file(raw_text="TJBQ 251150Z 00000KT 10SM 25/21 A2990",
+                               station_id="TJBQ",
+                               observation_time="2024-03-25T11:50:00Z",
+                               lat=18.494,
+                               lon=-67.128,
+                               temp_c=25.4,
+                               dew_point=21,
+                               wind_dir_degrees=5.4,
+                               wind_speed_kt=23.0,
+                               sky_condition=[]),
+            1725663600,
+
+            # ["id", "lon", "lat", "timestamp", "precip_rate", "precip_type", "px", "py", "tile_x", "tile_y",
+            # "sky_condition"]
+            [
+                ["TJBQ", -67.128, 18.494, 1711367400, 0.0, PrecipitationType.UNKNOWN.value, 33, 78, 40, 57,
+                 []]
+            ]
+        ),
+        # clear sky with sky condition reporting
         (
             _create_metar_file(raw_text="TJBQ 251150Z 00000KT 10SM CLR 25/21 A2990",
                                station_id="TJBQ",
@@ -70,17 +96,20 @@ class TestMetarParser:
                                temp_c=25.4,
                                dew_point=21,
                                wind_dir_degrees=5.4,
-                               wind_speed_kt=23.0),
+                               wind_speed_kt=23.0,
+                               sky_condition=['<sky_condition sky_cover="CLR"/>']),
             1725663600,
 
-            # ["id", "lon", "lat", "timestamp", "precip_rate", "precip_type", "px", "py", "tile_x", "tile_y"]
+            # ["id", "lon", "lat", "timestamp", "precip_rate", "precip_type", "px", "py", "tile_x", "tile_y",
+            # "sky_condition"]
             [
-                ["TJBQ", -67.128, 18.494, 1711367400, 0.0, PrecipitationType.UNKNOWN.value, 33, 78, 40, 57]
+                ["TJBQ", -67.128, 18.494, 1711367400, 0.0, PrecipitationType.UNKNOWN.value, 33, 78, 40, 57,
+                 [(SkyCover.CLR, CLOUD_BASE_UNDEFINED)]]
             ]
         ),
         # only rain
         (
-            _create_metar_file(raw_text="TJBQ 251150Z 00000KT 10SM RA 25/21 A2990",
+            _create_metar_file(raw_text="TJBQ 251150Z 00000KT 10SM RA FEW039 SCT049 BKN060 25/21 A2990",
                                station_id="TJBQ",
                                observation_time="2024-03-25T11:50:00Z",
                                lat=18.494,
@@ -88,17 +117,22 @@ class TestMetarParser:
                                temp_c=25.4,
                                dew_point=21,
                                wind_dir_degrees=5.4,
-                               wind_speed_kt=23.0),
+                               wind_speed_kt=23.0,
+                               sky_condition=['<sky_condition sky_cover="FEW" cloud_base_ft_agl="3900" />',
+                                              '<sky_condition sky_cover="SCT" cloud_base_ft_agl="4900" />',
+                                              '<sky_condition sky_cover="BKN" cloud_base_ft_agl="6000" />']),
             1725667200,
 
-            # ["id", "lon", "lat", "timestamp", "precip_rate", "precip_type", "px", "py", "tile_x", "tile_y"]
+            # ["id", "lon", "lat", "timestamp", "precip_rate", "precip_type", "px", "py", "tile_x", "tile_y",
+            # "sky_condition"]
             [
-                ["TJBQ", -67.128, 18.494, 1711367400, 10.0, PrecipitationType.RAIN.value, 33, 78, 40, 57]
+                ["TJBQ", -67.128, 18.494, 1711367400, 10.0, PrecipitationType.RAIN.value, 33, 78, 40, 57,
+                 [(SkyCover.FEW.value, 3900), (SkyCover.SCT.value, 4900), (SkyCover.BKN.value, 6000)]]
             ]
         ),
         # only snow
         (
-            _create_metar_file(raw_text="TJBQ 251150Z 00000KT 10SM SN 25/21 A2990",
+            _create_metar_file(raw_text="TJBQ 251150Z 00000KT 10SM SN OVC020 25/21 A2990",
                                station_id="TJBQ",
                                observation_time="2024-03-25T11:50:00Z",
                                lat=18.494,
@@ -106,12 +140,15 @@ class TestMetarParser:
                                temp_c=25.4,
                                dew_point=21,
                                wind_dir_degrees=5.4,
-                               wind_speed_kt=23.0),
+                               wind_speed_kt=23.0,
+                               sky_condition=['<sky_condition sky_cover="OVC" cloud_base_ft_agl="2000" />']),
             1725667200,
 
-            # ["id", "lon", "lat", "timestamp", "precip_rate", "precip_type", "px", "py", "tile_x", "tile_y"]
+            # ["id", "lon", "lat", "timestamp", "precip_rate", "precip_type", "px", "py", "tile_x", "tile_y",
+            # "sky_condition"]
             [
-                ["TJBQ", -67.128, 18.494, 1711367400, 10.0, PrecipitationType.SNOW.value, 33, 78, 40, 57]
+                ["TJBQ", -67.128, 18.494, 1711367400, 10.0, PrecipitationType.SNOW.value, 33, 78, 40, 57,
+                 [(SkyCover.OVC.value, 2000)]]
             ]
         ),
         # mix
@@ -124,12 +161,16 @@ class TestMetarParser:
                                temp_c=25.4,
                                dew_point=21,
                                wind_dir_degrees=5.4,
-                               wind_speed_kt=23.0),
+                               wind_speed_kt=23.0,
+                               sky_condition=['<sky_condition sky_cover="SCT" cloud_base_ft_agl="1000" />',
+                                              '<sky_condition sky_cover="BKN" cloud_base_ft_agl="1500" />']),
             1725667200,
 
-            # ["id", "lon", "lat", "timestamp", "precip_rate", "precip_type", "px", "py", "tile_x", "tile_y"]
+            # ["id", "lon", "lat", "timestamp", "precip_rate", "precip_type", "px", "py", "tile_x", "tile_y",
+            # "sky_condition"]
             [
-                ["TJBQ", -67.128, 18.494, 1711367400, 10.0, PrecipitationType.MIX.value, 33, 78, 40, 57]
+                ["TJBQ", -67.128, 18.494, 1711367400, 10.0, PrecipitationType.MIX.value, 33, 78, 40, 57,
+                 [(SkyCover.SCT.value, 1000), (SkyCover.BKN.value, 1500)]]
             ]
         )
     ])


### PR DESCRIPTION
<!--
ℹ️  Thank you for contributing!  
     Provide as much detail as possible so reviewers can work efficiently.
-->

# 📋  Pull Request

## ✨  Summary
<!-- A concise, meaningful description of *what* this PR does and *why*. -->
The code for sky(cloud) condition parsing was introduced. The typical METAR record look like 
```
      <sky_condition sky_cover="SCT" cloud_base_ft_agl="3500" />
      <sky_condition sky_cover="FEW" cloud_base_ft_agl="4000" />
      <sky_condition sky_cover="SCT" cloud_base_ft_agl="10000" />
```

The "sky_cover" and "cloud_base_xxx" records is converted to the array like structures and stored (see class SkyCover for mapping). This is preparation for calculating cloud coverage metrics.

## 🔗  Related Issue(s)
<!--
List the issue(s) this PR closes.
Use the “Closes #123” / “Fixes #123” / “Resolves #123” syntax to create links.
-->
Closes #

---

## 🧪  Testing & Verification
<!--
Explain how you verified your changes (unit tests, manual QA, screenshots, etc.).
If no tests are needed, briefly justify why.
-->
- [x] Unit tests added/updated
- [x] Tested locally

## 🚨  Breaking Changes?
<!--
Does this PR introduce breaking API/CLI/config changes?
If **yes**, describe impact and migration steps.
-->
- [ ] Yes
- [x] No

## 🚀  Deployment Notes
<!--
Any special steps, migrations, config flags, or env vars needed after merge?
-->
- 

## 📝  Checklist
- [x] PR is rebased on `main` and up‑to‑date with latest commits
- [x] CI is green (tests, lint, type‑check)
- [ ] Documentation updated (README, CHANGELOG, docs site)
- [x] Added myself to CONTRIBUTORS.md (if new contributor)

## 🙋‍♂️  Reviewer Notes
<!--
Anything the reviewer should pay special attention to (edge cases, tricky logic)?
Mention teams or individuals you’d like to review.
-->
