### PR TITLE
Fix empty pandas concatenation warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,11 @@ docker-publish-sensors:docker-build-sensors
 
 # testing
 test:
-	export PYTHONPATH="${PYTHONPATH}:$(pwd)" && \
+	export PYTHONPATH="${PYTHONPATH}:$(CURDIR):$(CURDIR)/tools" && \
 	pytest tests/
 
 # test coverage
 coverage:
-	export PYTHONPATH="${PYTHONPATH}:$(pwd)" && \
+	export PYTHONPATH="${PYTHONPATH}:$(CURDIR):$(CURDIR)/tools" && \
 	coverage run --rcfile=.coveragerc -m pytest tests/ && \
 	coverage report --show-missing

--- a/metrics/calc/forecast_manager.py
+++ b/metrics/calc/forecast_manager.py
@@ -10,6 +10,7 @@ from metrics.data_vendor import BaseDataVendor, DataVendor
 
 from metrics.session import Session
 from metrics.utils.time import floor_timestamp
+from metrics.utils.frame import concat_frames
 
 from rich.console import Console
 
@@ -82,7 +83,8 @@ class ForecastManager:
         Returns
         -------
         pandas.DataFrame
-            Table with forecast for each sensor that has next columns: "id", "precip_rate", "precip_type", "forecast_time"
+            Table with forecast for each sensor that has next columns:
+                "id", "precip_rate", "precip_type", "forecast_time", "timestamp"
         """
 
         sensor_ids = set(sensors_table["id"].unique())
@@ -111,4 +113,5 @@ class ForecastManager:
 
             curr_time += ForecastManager.DATA_STEP
 
-        return pandas.concat(loaded_forecasts)
+        return concat_frames(frames=loaded_forecasts,
+                             columns=["id", "precip_type", "precip_rate", "timestamp", "forecast_time"])

--- a/metrics/calc/utils.py
+++ b/metrics/calc/utils.py
@@ -2,6 +2,8 @@ import os
 import pandas
 import typing
 
+from metrics.utils.frame import concat_frames
+
 
 def read_selected_sensors(path: typing.Optional[str] = None) -> pandas.DataFrame:
     """Read path and return list of selected sensor IDs.
@@ -12,9 +14,10 @@ def read_selected_sensors(path: typing.Optional[str] = None) -> pandas.DataFrame
         Path to directory or a file (.csv, .csv.zip or .parquet) where to find data with sensor id's.
         Column "id" is mandatory in data.
     """
+    frame_columns = ["id", "lon", "lat", "count", "country"]
 
     if path is None:
-        return pandas.DataFrame(columns=["id", "lon", "lat", "count", "country"])
+        return pandas.DataFrame(columns=frame_columns)
 
     if os.path.isdir(path):
         aggregated_sensors_data = []
@@ -22,7 +25,8 @@ def read_selected_sensors(path: typing.Optional[str] = None) -> pandas.DataFrame
             file_path = os.path.join(path, file_name)
             aggregated_sensors_data.append(read_selected_sensors(file_path))
 
-        return pandas.concat(aggregated_sensors_data)
+        return concat_frames(frames=aggregated_sensors_data,
+                             columns=frame_columns)
     elif path.endswith(".csv"):
         return pandas.read_csv(path)
     elif path.endswith(".parquet"):
@@ -30,4 +34,4 @@ def read_selected_sensors(path: typing.Optional[str] = None) -> pandas.DataFrame
     elif path.endswith(".zip"):
         return pandas.read_csv(path, compression="zip")
 
-    return pandas.DataFrame(columns=["id", "lon", "lat", "count", "country"])
+    return pandas.DataFrame(columns=frame_columns)

--- a/metrics/utils/frame.py
+++ b/metrics/utils/frame.py
@@ -1,0 +1,9 @@
+import pandas
+
+
+def concat_frames(frames: list[pandas.DataFrame], columns: list[str]) -> pandas.DataFrame:
+    frames = [i for i in frames if len(i) > 0]  # remove empty frames
+    if len(frames) > 0:
+        return pandas.concat(frames)
+    else:
+        return pandas.DataFrame(columns=columns)


### PR DESCRIPTION
<!--
ℹ️  Thank you for contributing!  
     Provide as much detail as possible so reviewers can work efficiently.
-->

# 📋  Pull Request

## ✨  Summary
<!-- A concise, meaningful description of *what* this PR does and *why*. -->
Fix warnings:
```
/metrics/weatherindex/metrics/calc/forecast_manager.py:114: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
  return pandas.concat(loaded_forecasts)
```

## 🧪  Testing & Verification
<!--
Explain how you verified your changes (unit tests, manual QA, screenshots, etc.).
If no tests are needed, briefly justify why.
-->
- [ ] Unit tests added/updated
- [x] Tested locally

## 🚨  Breaking Changes?
<!--
Does this PR introduce breaking API/CLI/config changes?
If **yes**, describe impact and migration steps.
-->
- [ ] Yes
- [x] No

## 📝  Checklist
- [x] PR is rebased on `main` and up‑to‑date with latest commits
- [x] CI is green (tests, lint, type‑check)
- [ ] Documentation updated (README, CHANGELOG, docs site)
- [x] Added myself to CONTRIBUTORS.md (if new contributor)

## 🙋‍♂️  Reviewer Notes
<!--
Anything the reviewer should pay special attention to (edge cases, tricky logic)?
Mention teams or individuals you’d like to review.
-->
